### PR TITLE
Put current_fiber to a thread local variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 C_SRC = $(wildcard src/*.c)
 C_OBJ = $(C_SRC:.c=.o)
 ASM = $(wildcard src/arch/$(shell uname -m)/*.S)
-LDFLAGS = -luring
+LDFLAGS = -luring -lpthread
 CFLAGS = -g
 
 rocket_io: $(C_OBJ) $(ASM)

--- a/src/arch/x86_64/switch.S
+++ b/src/arch/x86_64/switch.S
@@ -1,7 +1,6 @@
 .global switch_run_context
 .global init_run_context
 .global execute_start
-.global get_current_fiber
 
 # Initialize stack for an execution context.
 #
@@ -36,9 +35,10 @@ init_run_context:
 
 # Switch from one execution context to another.
 #
-# rdi: src_stk_ptr [in, out] Current (source) stack pointer.
-# rsi: dst_stk_ptr [in] Pointer to the stack to switch to.
-# rdx: dst_fiber   [in] Pointer to the fiber to switch to.
+# rdi: src_stk_ptr     [in, out] Current (source) stack pointer.
+# rsi: dst_stk_ptr     [in] Pointer to the stack to switch to.
+# rdx: switch_context  [in] The context passed to switch_callback.
+# rcx: switch_callback [in] Callback invoked after switching.
 #
 switch_run_context:
   # Push all callee-saved registers to the current stack.
@@ -56,7 +56,9 @@ switch_run_context:
   # Update the stack pointer to dst_stk_ptr
   movq %rsi, %rsp
 
-  movq %rdx, %fs:0 # Set current fiber
+  # Call switch_callback(switch_context)
+  movq %rdx, %rdi
+  callq *%rcx
 
   popq %rdi # HACK: for the entry_point_context
   # Pop all callee-saved registers from the new stack.
@@ -68,9 +70,4 @@ switch_run_context:
   popq %rbp
 
   # This will return to the dst fiber
-  retq
-
-# Get the pointer to current fiber
-get_current_fiber:
-  movq %fs:0, %rax
   retq

--- a/src/rocket_executor.h
+++ b/src/rocket_executor.h
@@ -15,3 +15,6 @@ rocket_fiber_t* rocket_executor_submit_task(
 void rocket_executor_execute(rocket_executor_t* executor);
 void rocket_executor_destroy(rocket_executor_t* executor);
 rocket_engine_t* rocket_executor_get_engine(rocket_executor_t* executor);
+
+rocket_fiber_t* get_current_fiber();
+

--- a/src/switch.h
+++ b/src/switch.h
@@ -7,8 +7,7 @@ void init_run_context(
     void* entry_point_context);
 // src_stk_ptr will be updated to current stack pointer.
 // Then current stack pointer will be updated to dst_stk_ptr.
-void switch_run_context(void** src_stk_ptr, void* dst_stk_ptr, void* dst_fiber);
-
-void* get_current_fiber();
+void switch_run_context(void **src_stk_ptr, void *dst_stk_ptr,
+                        void *switch_context, void (*switch_callback)(void *));
 
 void execute_start(void* stk_ptr);


### PR DESCRIPTION
# Summary
Current code puts the point to current fiber on `%fs:0` register, which may have conflict with other thread local variables. This change puts it into a thread local variable to avoid potential conflicts.

Changes in this commit:
* Add a `set_current_fiber` function which sets a thread local variable to the given fiber.
* Add a `get_current_fiber` function which returns the thread local variable.
* Add a `switch_callback` param to `switch_run_context`. Currently, `set_current_fiber` is passed as this param at all callsites.
* Split the tasks executed in main to 2 pthreads.

# Test Plan:
```
$ make clean; make && ./rocket_io
```