### PR TITLE
add 8-byte padding setting up initial stack frame on x86_64

### DIFF
--- a/src/arch/x86_64/switch.S
+++ b/src/arch/x86_64/switch.S
@@ -13,12 +13,19 @@ init_run_context:
 
   # Get the stack pointer
   movq (%rdi), %rsp # rdi = &stk_ptr
-  # Push the entry point address to the stack.
+
+  # Load a dummy value that will be pushed on the stack in place of valid
+  # register values.
+  movq $0xBADC0FFEEDEADDAD, %r10
+
+  // First, push the entry point address to the stack and a dummy frame pointer
+  // value. The entry point address will be "returned" to the first time
+  // switch_run_context is called on the new execution context.
+  pushq %r10
   pushq %rsi # rsi = entry_point
 
   # Push dummy values to the stack for all callee saved register positions.
   # These will be popped in switch_run_context.
-  movq $0xDEADBEEFC0FFEE41, %r10
   pushq %r10 # rbp
   pushq %r10 # rbx
   pushq %r10 # r12


### PR DESCRIPTION
This change makes the x86_64 implementation consistent with the aarch64 implementation by pushing a dummy frame pointer value onto the stack before the entry point address. This ensures the stack is 16-byte aligned after the entry point (which is actually used as a return address invoked via `ret`) is pushed. 16-byte stack alignment is required as part of the x86_64 calling convention.

Tested on Ubuntu 21.10 w/5.13.0 kernel, which previously resulted in a segfault due to the unaligned stack pointer when issuing a `movaps` instruction.

```
$ make clean
$ make rocket_io
$ ./rocket_io
```
observed success

```
$ make benchmark_file_io
$ ./benchmark_file_io -n 10 -c 10 -s 4096
```
observed success