### PR TITLE
Pad the stack on x86_64 by 8-bytes to preserve expected alignment

### DIFF
--- a/src/arch/x86_64/switch.S
+++ b/src/arch/x86_64/switch.S
@@ -13,6 +13,10 @@ init_run_context:
 
   # Get the stack pointer
   movq (%rdi), %rsp # rdi = &stk_ptr
+
+  # Push 8 byte padding to the stack for proper 16-byte stack alignment
+  pushq $0
+
   # Push the entry point address to the stack.
   pushq %rsi # rsi = entry_point
 


### PR DESCRIPTION
The x86_64 calling convention requires stacks to be 16-byte aligned. The current implementation only guarantees 8-byte alignment, which mostly works but fails when executing instructions that expect 16-byte alignment such as `movabs`.

### Background
In gdb, we've observed that on normal function entry, the `%rsp` is always 8-byte rather than 16-byte aligned. This is because the `call` instruction pushes the 8-byte return address to the currently 16-byte aligned stack. So on function entry the stack pointer is always 8 bytes below the last 16-byte aligned stack pointer. Compilers seem to expect this alignment and generate a preamble that immediately pushes the current frame pointer (`%rbp`) to the stack, thus making `%rsp` 16-byte aligned. Code generate in the rest of the function may rely on this alignment, as we observed in the disassembly for the glibc-2.34 implementation of `__vfprintf_internal` distributed with recent Ubuntu versions (which use the `movabs` instruction on `%xmm` registers, requiring 16-byte alignment).

### Issue
In the fiber implementation, the initial fiber entry point function is invoked via a `ret` instruction rather than `call`. Without this patch, the function begins with `%rsp` aligned at 16-bytes because no return address was pushed to the stack: `ret` pops an address from the stack, while `call` pushes an address to the stack. The compiler-generated function preamble immediately pushes `%rbp` making it no longer 16-byte aligned as expected.

### Solution
This patch fixes the problem by pushing one addition 8-byte value on the stack immediately before pushing the entry point function address. This ensures that when we `ret` to the entry point function the stack is 8-bytes less than the next 16-byte aligned address matching the expected alignment of `%rsp` had the function been invoked with a `call` instruction rather than a `ret` instruction.

A value of `0` was chosen as padding because it appears as the next frame in a back-trace in the debugger, which is more sensible than an arbitrary sentinel value:
```
(gdb) bt
#0  func_odd (context=0x0) at src/main.c:19
#1  0x0000000000402386 in rocket_task_func_wrapper (context=0x7ffff00010b0) at src/rocket_executor.c:61
#2  0x0000000000000000 in ?? ()
```

### Verification
Tested on Ubuntu 21.10 w/5.13.0 kernel, which previously resulted in a segfault due to the unaligned stack pointer when issuing a `movaps` instruction in `__vfprintf_internal`.
```
$ make clean
$ make rocket_io
$ ./rocket_io
```
observed success
```
$ make benchmark_file_io
$ ./benchmark_file_io -n 10 -c 10 -s 4096
```
observed success