### PR TITLE
Fix build warning in benchmark test

### DIFF
--- a/include/rocket/rocket_engine.h
+++ b/include/rocket/rocket_engine.h
@@ -32,7 +32,7 @@
 rocket_engine_t* rocket_engine_create(size_t queue_depth);
 void rocket_engine_destroy(rocket_engine_t* engine);
 
-int openat_await(int dirfd, const char* pathname, int oflag, mode_t pmode);
+int openat_await(int dirfd, const char* pathname, int oflag, ...);
 ssize_t readat_await(int fd, void* buf, size_t nbyts, off_t offset);
 ssize_t writeat_await(int fd, const void* buf, size_t nbyts, off_t offset);
 int close_await(int fd);

--- a/src/benchmark/benchmark_file_io.c
+++ b/src/benchmark/benchmark_file_io.c
@@ -37,7 +37,7 @@
 #include "benchmark_common.h"
 
 typedef struct {
-  int (*openat)(int dirfd, const char *pathname, int oflag, mode_t mode);
+  int (*openat)(int dirfd, const char *pathname, int oflag, ...);
   ssize_t (*readat)(int fd, void *buf, size_t nbyts, off_t offset);
   ssize_t (*writeat)(int fd, const void *buf, size_t nbyts, off_t offset);
   int (*close)(int fd);

--- a/src/rocket_engine_uring.c
+++ b/src/rocket_engine_uring.c
@@ -137,11 +137,11 @@ static void prepare_openat(struct io_uring_sqe* sqe, void* context) {
 
 int openat_await(int dirfd, const char* pathname, int oflag, ...) {
   mode_t pmode = 0;
-  if (__OPEN_NEEDS_MODE (oflag)) {
-    va_list arg;
-    va_start(arg, oflag);
-    pmode = va_arg(arg, mode_t);
-    va_end(arg);
+  if (__OPEN_NEEDS_MODE(oflag)) {
+    va_list args;
+    va_start(args, oflag);
+    pmode = va_arg(args, mode_t);
+    va_end(args);
   }
 
   openat_context_t context;

--- a/src/rocket_engine_uring.c
+++ b/src/rocket_engine_uring.c
@@ -24,6 +24,7 @@
  */
 
 #include <liburing.h>
+#include <stdarg.h>
 #include <stdio.h>
 
 #include <rocket/rocket_engine.h>
@@ -134,7 +135,15 @@ static void prepare_openat(struct io_uring_sqe* sqe, void* context) {
       openat_context->pmode);
 }
 
-int openat_await(int dirfd, const char* pathname, int oflag, mode_t pmode) {
+int openat_await(int dirfd, const char* pathname, int oflag, ...) {
+  mode_t pmode = 0;
+  if (__OPEN_NEEDS_MODE (oflag)) {
+    va_list arg;
+    va_start(arg, oflag);
+    pmode = va_arg(arg, mode_t);
+    va_end(arg);
+  }
+
   openat_context_t context;
   context.dirfd = dirfd;
   context.pathname = pathname;


### PR DESCRIPTION
Make the function `openat_await` signature identical to `openat` using `va_args`. This change avoids a compiler typecast warning when building the benchmark test.

Test Plan:
```
$ ./configure
$ make clean
$ make rocket_io_demo benchmark_file_io echo_server
$ ./benchmark_file_io -n 1000 -c 100 -s 65536
------------------------------------------------------
Benchmarking read write files with pthreads with params:
[1000 threads, 100 IO cycles per thread, 65536 bytes per IO]

Finished read write files with pthreads in 2.002608 seconds CPU time, 0.189196 seconds real time
------------------------------------------------------
------------------------------------------------------
Benchmarking read write files with fibers with params:
[1000 threads, 100 IO cycles per thread, 65536 bytes per IO]

Finished read write files with fibers in 6.841431 seconds CPU time, 1.834003 seconds real time
------------------------------------------------------
```