### PR TITLE
Fix SIGSEGV in demo program when compiled with gcc

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -70,8 +70,12 @@ static void big_stack_helper(int count) {
 }
 
 static void* big_stack(void* context) {
+  /* Fibers are given a max stack of 64KiB. This recursive call attempts to
+   * access as much of it as possible. Hold out one full page for whatever
+   * the compiler implicitly puts on the stack that we can't control.
+   */
   const size_t depth = 65536 / getpagesize() - 1;
-  big_stack_helper(depth);
+  big_stack_helper(depth - 1);
   return NULL;
 }
 


### PR DESCRIPTION
When compiled with gcc, the big stack test that runs as part of the demo/test program hits a SIGSEGV when it attempts to access beyond the max fiber stack size of 64KiB. The test was supposed to perform 15 page size stack allocations, leaving some space for other stack use added by the compiler, but was mistakenly implemented to perform 16 of them. This works when compiled with clang (though the 17th will hit a SIGSEGV) but it can only allocate 15 when compiled with gcc.

This change fixes the original bug in the test and the test runs fine when compiled with either gcc or clang.

### Test Plan:
```
$ ./configure
$ make clean
$ make rocket_io_demo
$ ./rocket_io_demo
START thread 1
START thread 2
========== BEGIN open_write_read_close ==========
0
1
2
3
hello from foo
4
5
6
7
8
9
hello from bar
========== fd for pikachu is 5 ==========
fd for foo0 is 6
fd for bar0 is 7
========== Wrote 37 bytes to file pikachu (fd 5) ==========
========== Read 37 bytes from file pikachu (fd 5) ==========
========== END open_write_read_close ==========
fd for foo1 is 6
END thread 1
fd for bar1 is 5
fd for foo2 is 3
fd for bar2 is 3
fd for foo3 is 5
fd for bar3 is 3
fd for foo4 is 5
fd for bar4 is 3
fd for foo5 is 5
fd for bar5 is 3
fd for foo6 is 5
fd for bar6 is 3
fd for foo7 is 5
fd for bar7 is 3
fd for foo8 is 5
fd for bar8 is 3
fd for foo9 is 5
fd for bar9 is 3
fd for foo10 is 5
fd for bar10 is 3
fd for foo11 is 5
fd for bar11 is 3
fd for foo12 is 5
fd for bar12 is 3
fd for foo13 is 5
fd for bar13 is 3
fd for foo14 is 5
fd for bar14 is 3
fd for foo15 is 5
fd for bar15 is 3
fd for foo16 is 5
fd for bar16 is 3
fd for foo17 is 5
fd for bar17 is 3
fd for foo18 is 5
fd for bar18 is 3
fd for foo19 is 5
fd for bar19 is 3
fd for foo20 is 5
fd for bar20 is 3
fd for foo21 is 5
fd for bar21 is 3
fd for foo22 is 5
fd for bar22 is 3
fd for foo23 is 5
fd for bar23 is 3
fd for foo24 is 5
fd for bar24 is 3
fd for foo25 is 5
fd for bar25 is 3
fd for foo26 is 5
fd for bar26 is 3
fd for foo27 is 5
fd for bar27 is 3
fd for foo28 is 5
fd for bar28 is 3
fd for foo29 is 5
fd for bar29 is 3
fd for foo30 is 5
fd for bar30 is 3
fd for foo31 is 5
fd for bar31 is 3
END thread 2
completed
```